### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,6 +8,9 @@
 
 name: Java CI with Maven
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/seanmobrien/we-dont-need-no-education/security/code-scanning/1](https://github.com/seanmobrien/we-dont-need-no-education/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily builds and tests code, it only needs `contents: read` permissions. This can be added at the root level of the workflow to apply to all jobs.

**Steps to implement the fix:**
1. Add a `permissions` block at the root level of the workflow file, specifying `contents: read`.
2. Ensure no unnecessary write permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
