### PR TITLE
Potential fix for code scanning alert no. 35: Insecure randomness

### DIFF
--- a/web-ui/packages/app/lib/ai/agents/timeline/agent-server.ts
+++ b/web-ui/packages/app/lib/ai/agents/timeline/agent-server.ts
@@ -535,7 +535,7 @@ class ServerTimelineAgent extends ClientTimelineAgent {
         originatingUserId: this.#userId ?? '-1',
         operation: operation ? `timeline:${operation}` : 'timeline:agent',
         opTags: opProps,
-        chatId: generateChatId(Math.random() * 1000).id,
+        chatId: generateChatId().id,
       });
       if (!this.#chatHistoryContext) {
         throw new TypeError('Unknown failure creating chat history context.');

--- a/web-ui/packages/app/lib/ai/middleware/chat-history/create-chat-history-context.ts
+++ b/web-ui/packages/app/lib/ai/middleware/chat-history/create-chat-history-context.ts
@@ -109,8 +109,9 @@ export const createAgentHistoryContext = ({
       traceFlags,
     },
   };
+  const secureRandomId = generateChatId().id;
   const chatId =
-    chatIdFromProps ?? generateChatId(`agent-${operation}-${Date.now()}`).id;
+    chatIdFromProps ?? `agent-${operation}-${secureRandomId}`;
   return hydrateContext({
     userId: String(AgentUserId),
     chatId: chatId,


### PR DESCRIPTION
Potential fix for [https://github.com/seanmobrien/we-dont-need-no-education/security/code-scanning/35](https://github.com/seanmobrien/we-dont-need-no-education/security/code-scanning/35)

In general, to fix insecure randomness, avoid seeding or basing security‑sensitive IDs on `Math.random` or other non‑cryptographic PRNGs. Instead, use a CSPRNG such as Node’s `crypto.randomBytes` (here already wrapped as `cryptoRandomBytes`) and functions that are explicitly designed to be secure, like the no‑seed path of `generateChatId`.

The best targeted fix here is:

1. Stop passing `Math.random()` as a seed to `generateChatId` in `ServerTimelineAgent.generateResponse`. Calling `generateChatId()` with no argument uses the secure branch that draws bytes from `cryptoRandomBytes`.
2. Optionally, ensure that when `createAgentHistoryContext` needs to create a `chatId` (when `chatIdFromProps` is absent), it also uses the secure no‑seed path. Right now it passes a string seed (`agent-${operation}-${Date.now()}`) which forces the insecure LCG path. We can make it use the secure path simply by calling `generateChatId()` without arguments and composing any operation metadata into the `chatId` string separately if needed. To preserve behavior shape, we can instead prefix the generated secure ID with the existing `agent-${operation}-` pattern but not as a seed, i.e., build a string combining the deterministic prefix with a secure random suffix.

Concretely:

- In `web-ui/packages/app/lib/ai/agents/timeline/agent-server.ts`, change `chatId: generateChatId(Math.random() * 1000).id` to `chatId: generateChatId().id`. This keeps `chatId` format as an 8‑character random string but makes it cryptographically secure.
- In `web-ui/packages/app/lib/ai/middleware/chat-history/create-chat-history-context.ts`, change the fallback `chatId` computation from `generateChatId(\`agent-${operation}-${Date.now()}\`).id` to something that uses a secure random ID. A minimal and compatible option is: `const randomPart = generateChatId().id; const chatId = chatIdFromProps ?? \`agent-${operation}-${randomPart}\`;`. This preserves the `agent-<operation>-<something>` structure while making `<something>` securely random.

No new methods or external dependencies are needed; we reuse the existing `generateChatId` secure path. All changes are within the shown files.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
